### PR TITLE
Fix cannot mark step with no final step label

### DIFF
--- a/ProcessControl.html
+++ b/ProcessControl.html
@@ -234,7 +234,6 @@
             else if(selectedStepElement){
                 if(finalStep)
                     finalStep.resetFinalStepLabel();
-                finalStep.resetFinalStepLabel();
                 setArrowActive(selectedStepElement);
             }
         }


### PR DESCRIPTION
Bugfix 1: Fixed state when user could not mark current step. This was caused by final step label not being configured.